### PR TITLE
feat: attempt to declutter map a bit

### DIFF
--- a/gravel-style.json
+++ b/gravel-style.json
@@ -10,7 +10,10 @@
     "openmaptiles:mapbox:source:url": "mapbox://openmaptiles.4qljc88t"
   },
   "sources": {
-    "openmaptiles": {"type": "vector", "url": "https://map-tiles.m11n.de/gravel/vector/m11n/data/v3.json"}
+    "openmaptiles": {
+      "type": "vector",
+      "url": "https://map-tiles.m11n.de/gravel/vector/m11n/data/v3.json"
+    }
   },
   "sprite": "https://demotiles.maplibre.org/styles/osm-bright-gl-style/sprite",
   "glyphs": "https://api.maptiler.com/fonts/{fontstack}/{range}.pbf?key={key}",
@@ -353,7 +356,8 @@
           "horrible",
           "very_horrible",
           "impassable"
-        ]
+        ],
+        ["!in", "tracktype", "grade5", "grade4"]
       ],
       "layout": {
         "line-cap": "square",
@@ -389,7 +393,8 @@
           "horrible",
           "very_horrible",
           "impassable"
-        ]
+        ],
+        ["!in", "tracktype", "grade5", "grade4"]
       ],
       "layout": {
         "line-cap": "square",
@@ -428,7 +433,8 @@
           "compacted",
           "cobblestone",
           "sett",
-          "unhewn_cobblestone"
+          "unhewn_cobblestone",
+          "paving_stones"
         ],
         ["!in", "bicycle", "no"],
         ["!in", "access", "no"]
@@ -723,27 +729,14 @@
     },
     {
       "id": "cemetery",
-      "type": "fill",
+      "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "landuse",
       "filter": ["all", ["==", "class", "cemetery"]],
-      "paint": {
-        "fill-antialias": true,
-        "fill-outline-color": "rgba(0, 78, 157, 1)",
-        "fill-pattern": "cemetery_11",
-        "fill-opacity": 0.8
-      }
-    },
-    {
-      "id": "cemetery-outline",
-      "type": "line",
-      "source": "openmaptiles",
-      "source-layer": "landuse",
-      "filter": ["all", ["==", "class", "cemetery"]],
-      "paint": {
-        "line-color": "rgba(0, 0, 0, 1)",
-        "line-width": 1.3,
-        "line-opacity": 0.5
+      "layout": {
+        "icon-image": "cemetery_11",
+        "icon-rotation-alignment": "map",
+        "icon-size": 1.3
       }
     },
     {
@@ -751,24 +744,18 @@
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "poi",
-      "filter": ["all", ["==", "class", "drinking_water"]],
+      "minzoom": 9,
+      "maxzoom": 20,
+      "filter": [
+        "any",
+        ["==", "class", "drinking_water"],
+        ["==", "subclass", "drinking_water"]
+      ],
       "layout": {
-        "text-field": "Trinkwasser",
         "icon-image": "drinking_water_11",
         "visibility": "visible",
-        "text-size": 12,
-        "text-rotation-alignment": "auto",
-        "text-transform": "none",
-        "text-offset": [0, 1],
-        "text-font": ["Open Sans Semibold"],
-        "icon-text-fit": "none"
-      },
-      "paint": {
-        "icon-color": "rgba(21, 105, 221, 1)",
-        "text-color": "rgba(21, 105, 221, 1)",
-        "text-halo-color": "rgba(255, 255, 255, 1)",
-        "text-halo-width": 0.8,
-        "text-halo-blur": 0
+        "icon-rotation-alignment": "map",
+        "icon-size": 1.4
       }
     }
   ],

--- a/style.json
+++ b/style.json
@@ -10,7 +10,10 @@
     "openmaptiles:mapbox:source:url": "mapbox://openmaptiles.4qljc88t"
   },
   "sources": {
-    "openmaptiles": {"type": "vector", "url": "http://gravel:8080/data/v3.json"}
+    "openmaptiles": {
+      "type": "vector",
+      "url": "http://gravel:8080/data/v3.json"
+    }
   },
   "sprite": "https://demotiles.maplibre.org/styles/osm-bright-gl-style/sprite",
   "glyphs": "https://api.maptiler.com/fonts/{fontstack}/{range}.pbf?key={key}",
@@ -353,7 +356,8 @@
           "horrible",
           "very_horrible",
           "impassable"
-        ]
+        ],
+        ["!in", "tracktype", "grade5", "grade4"]
       ],
       "layout": {
         "line-cap": "square",
@@ -389,7 +393,8 @@
           "horrible",
           "very_horrible",
           "impassable"
-        ]
+        ],
+        ["!in", "tracktype", "grade5", "grade4"]
       ],
       "layout": {
         "line-cap": "square",
@@ -428,7 +433,8 @@
           "compacted",
           "cobblestone",
           "sett",
-          "unhewn_cobblestone"
+          "unhewn_cobblestone",
+          "paving_stones"
         ],
         ["!in", "bicycle", "no"],
         ["!in", "access", "no"]
@@ -723,27 +729,14 @@
     },
     {
       "id": "cemetery",
-      "type": "fill",
+      "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "landuse",
       "filter": ["all", ["==", "class", "cemetery"]],
-      "paint": {
-        "fill-antialias": true,
-        "fill-outline-color": "rgba(0, 78, 157, 1)",
-        "fill-pattern": "cemetery_11",
-        "fill-opacity": 0.8
-      }
-    },
-    {
-      "id": "cemetery-outline",
-      "type": "line",
-      "source": "openmaptiles",
-      "source-layer": "landuse",
-      "filter": ["all", ["==", "class", "cemetery"]],
-      "paint": {
-        "line-color": "rgba(0, 0, 0, 1)",
-        "line-width": 1.3,
-        "line-opacity": 0.5
+      "layout": {
+        "icon-image": "cemetery_11",
+        "icon-rotation-alignment": "map",
+        "icon-size": 1.3
       }
     },
     {
@@ -751,24 +744,18 @@
       "type": "symbol",
       "source": "openmaptiles",
       "source-layer": "poi",
-      "filter": ["all", ["==", "class", "drinking_water"]],
+      "minzoom": 9,
+      "maxzoom": 20,
+      "filter": [
+        "any",
+        ["==", "class", "drinking_water"],
+        ["==", "subclass", "drinking_water"]
+      ],
       "layout": {
-        "text-field": "Trinkwasser",
         "icon-image": "drinking_water_11",
         "visibility": "visible",
-        "text-size": 12,
-        "text-rotation-alignment": "auto",
-        "text-transform": "none",
-        "text-offset": [0, 1],
-        "text-font": ["Open Sans Semibold"],
-        "icon-text-fit": "none"
-      },
-      "paint": {
-        "icon-color": "rgba(21, 105, 221, 1)",
-        "text-color": "rgba(21, 105, 221, 1)",
-        "text-halo-color": "rgba(255, 255, 255, 1)",
-        "text-halo-width": 0.8,
-        "text-halo-blur": 0
+        "icon-rotation-alignment": "map",
+        "icon-size": 1.4
       }
     }
   ],


### PR DESCRIPTION
It's a start, and I'm just trying to get my hands dirty for now :). Changes are

- Don't fill entire cemeteries with repeating symbols. I live next to the largest cemetery in Germany, it takes up a *lot* of space! Use one symbol instead. Get rid of outline layer entirely
- Got rid of text under drinking water (couldn't figure out why most only show up at zoom 14, that's still TBD)
- Some more filtering for gravel layers:
  - `grade4` and `grade5` are not what we'd call gravel
  - neither is `paving_stones`, which basically covers all sidewalks in Berlin

IMHO there's still a bit too much going on to get the useful information at a glance but thought I'd work through it incrementally :)